### PR TITLE
More and more updates and fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ A command line interface app that uses this library exists. Most of the testing 
 Find it here: https://github.com/davidnewhall/SecSpyCLI - full of great examples on how to use this library.
 
 
-- Requires [SecuritySpy 4.2.10b7](https://www.bensoftware.com/securityspy/download-beta.html) or later.
+- Requires [SecuritySpy 4.2.10b9](https://www.bensoftware.com/securityspy/download-beta.html) or later.

--- a/cameras.go
+++ b/cameras.go
@@ -216,18 +216,20 @@ func (c *Camera) TriggerMotion() error {
 }
 
 // SetSchedule configures a camera mode's primary schedule.
-func (c *Camera) SetSchedule(mode CameraMode, schedule Schedule) error {
+// Get a list of schedules/IDs from server.Info.Schedules
+func (c *Camera) SetSchedule(mode CameraMode, scheduleID int) error {
 	params := make(url.Values)
 	params.Set("mode", string(mode))
-	params.Set("id", strconv.Itoa(schedule.ID))
+	params.Set("id", strconv.Itoa(scheduleID))
 	return c.server.simpleReq("++ssSetSchedule", params, c.Number)
 }
 
 // SetScheduleOverride temporarily overrides a camera mode's current schedule.
-func (c *Camera) SetScheduleOverride(mode CameraMode, scheduleOverride ScheduleOverride) error {
+// Get a list of overrides/IDs from server.Info.ScheduleOverrides
+func (c *Camera) SetScheduleOverride(mode CameraMode, overrideID int) error {
 	params := make(url.Values)
 	params.Set("mode", string(mode))
-	params.Set("id", string(scheduleOverride))
+	params.Set("id", string(overrideID))
 	return c.server.simpleReq("++ssSetOverride", params, c.Number)
 }
 

--- a/cameras_types.go
+++ b/cameras_types.go
@@ -7,13 +7,6 @@ import (
 // Encoder is the path to ffmpeg.
 var Encoder = "/usr/local/bin/ffmpeg"
 
-// ARM or DISARM a trigger
-const (
-	ErrorPTZNotOK = Error("PTZ command not OK")
-	ErrorPTZRange = Error("PTZ preset out of range 1-8")
-	ErrorCmdNotOK = Error("command unsuccessful")
-)
-
 // CameraArmMode locks arming to an integer of 0 or 1.
 type CameraArmMode rune
 

--- a/events.go
+++ b/events.go
@@ -88,8 +88,8 @@ func (e *Events) BindChan(event EventType, channel chan Event) {
 
 // Stop stops Watch() loops
 func (e *Events) Stop() {
+	defer func() { e.Running = false }()
 	if e.Running {
-		e.Running = false
 		e.stopChan <- e.Running
 	}
 }

--- a/events.go
+++ b/events.go
@@ -3,6 +3,7 @@ package securityspy
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 	"strconv"
 	"strings"
@@ -239,17 +240,17 @@ func (e *Events) parseEvent(text string) Event {
 			 20190114201206 104529 CAM5 ARM_A */
 	var err error
 	parts := strings.SplitN(text, " ", 4)
-	newEvent := Event{Msg: parts[3], Camera: nil, ID: -1, Errors: nil}
-	// Parse the time stamp
-	location := time.FixedZone("SVR", int(e.server.Info.GmtOffset.Seconds()))
-	if newEvent.When, err = time.ParseInLocation(eventTimeFormat, parts[0], location); err != nil {
+	newEvent := Event{Msg: parts[3], ID: -1}
+	// Parse the time stamp; append the Offset from ++systemInfo to get the right time-location.
+	eventTime := fmt.Sprintf("%v%+03.0f", parts[0], e.server.Info.GmtOffset.Hours())
+	if newEvent.When, err = time.ParseInLocation(eventTimeFormat+"-07", eventTime, time.Local); err != nil {
 		newEvent.When = time.Now()
 		newEvent.Errors = append(newEvent.Errors, ErrorDateParseFail)
 	}
-	newEvent.When = newEvent.When.In(time.Local) // Convert the time to local time.
+
 	// Parse the ID
 	if newEvent.ID, err = strconv.Atoi(parts[1]); err != nil {
-		newEvent.ID = -1
+		newEvent.ID = -2
 		newEvent.Errors = append(newEvent.Errors, ErrorIDParseFail)
 	}
 	// Parse the camera number.

--- a/events.go
+++ b/events.go
@@ -241,11 +241,12 @@ func (e *Events) parseEvent(text string) Event {
 	parts := strings.SplitN(text, " ", 4)
 	newEvent := Event{Msg: parts[3], Camera: nil, ID: -1, Errors: nil}
 	// Parse the time stamp
-	zone, _ := time.Now().Zone() // SecuritySpy preovides seconds-from-gmt, but it's wildly inaccurate.
-	if newEvent.When, err = time.Parse(eventTimeFormat+"MST", parts[0]+zone); err != nil {
+	location := time.FixedZone("SVR", int(e.server.Info.GmtOffset.Seconds()))
+	if newEvent.When, err = time.ParseInLocation(eventTimeFormat, parts[0], location); err != nil {
 		newEvent.When = time.Now()
 		newEvent.Errors = append(newEvent.Errors, ErrorDateParseFail)
 	}
+	newEvent.When = newEvent.When.In(time.Local) // Convert the time to local time.
 	// Parse the ID
 	if newEvent.ID, err = strconv.Atoi(parts[1]); err != nil {
 		newEvent.ID = -1

--- a/events_types.go
+++ b/events_types.go
@@ -3,22 +3,23 @@ package securityspy
 import (
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
-// Error strings used in this file.
-const (
-	ErrorUnknownEvent  = Error("unknown event")
-	ErrorCAMParseFail  = Error("CAM parse failed")
-	ErrorIDParseFail   = Error("ID parse failed")
-	ErrorCAMMissing    = Error("CAM missing")
-	ErrorDateParseFail = Error("timestamp parse failed")
-	ErrorUnknownError  = Error("unknown error")
-	ErrorDisconnect    = Error("event stream disconnected")
+var (
+	// Error strings used in this file.
+	ErrorUnknownEvent  = errors.New("unknown event")
+	ErrorCAMParseFail  = errors.New("CAM parse failed")
+	ErrorIDParseFail   = errors.New("ID parse failed")
+	ErrorCAMMissing    = errors.New("CAM missing")
+	ErrorDateParseFail = errors.New("timestamp parse failed")
+	ErrorUnknownError  = errors.New("unknown error")
+	ErrorDisconnect    = errors.New("event stream disconnected")
 	unknownEventText   = "Unknown Event"
+	// eventTimeFormat is the go-time-format returned by SecuritySpy's eventStream
+	eventTimeFormat = "20060102150405"
 )
-
-// eventTimeFormat is the go-time-format returned by SecuritySpy's eventStream
-var eventTimeFormat = "20060102150405"
 
 // Events is the main Events interface.
 type Events struct {

--- a/files.go
+++ b/files.go
@@ -42,7 +42,11 @@ func (f *Files) GetCCVideos(cameraNums []int, from, to time.Time) ([]*File, erro
 func (f *Files) GetFile(name string) (*File, error) {
 	//	01-18-2019 10-17-53 M Porch.m4v => ++getfile/0/2019-01-18/01-18-2019+10-17-53+M+Porch.m4v
 	var err error
-	file := new(File)
+	file := &File{
+		Title:     name,
+		server:    f.server,
+		GmtOffset: f.server.Info.GmtOffset.Duration,
+	}
 	if fileExtSplit := strings.Split(name, "."); len(fileExtSplit) != 2 {
 		return file, ErrorNoExtension
 	} else if nameDateSplit := strings.Split(fileExtSplit[0], " "); len(fileExtSplit) < 2 {
@@ -54,10 +58,7 @@ func (f *Files) GetFile(name string) (*File, error) {
 	} else if file.Link.Type = "video/quicktime"; fileExtSplit[1] == "jpg" {
 		file.Link.Type = "image/jpeg"
 	}
-	file.Title = name
-	file.server = f.server
 	file.CameraNum = file.Camera.Number
-	file.GmtOffset = f.server.Info.GmtOffset.Duration
 	file.Link.HREF = "++getfile/" + strconv.Itoa(file.CameraNum) + "/" +
 		file.Updated.Format(downloadDateFormat) + "/" + url.QueryEscape(name)
 	return file, nil

--- a/files.go
+++ b/files.go
@@ -57,7 +57,7 @@ func (f *Files) GetFile(name string) (*File, error) {
 	file.Title = name
 	file.server = f.server
 	file.CameraNum = file.Camera.Number
-	file.GmtOffset = f.server.Info.GmtOffset
+	file.GmtOffset = f.server.Info.GmtOffset.Duration
 	file.Link.HREF = "++getfile/" + strconv.Itoa(file.CameraNum) + "/" +
 		file.Updated.Format(downloadDateFormat) + "/" + url.QueryEscape(name)
 	return file, nil
@@ -70,7 +70,7 @@ func (f *File) Save(path string) (int64, error) {
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		return 0, ErrorPathExists
 	}
-	body, err := f.Get()
+	body, err := f.Get(true)
 	if err != nil {
 		return 0, err
 	}
@@ -90,9 +90,12 @@ func (f *File) Save(path string) (int64, error) {
 }
 
 // Get opens a file from a SecuritySpy link and returns the http.Body io.ReadCloser.
-func (f *File) Get() (io.ReadCloser, error) {
+func (f *File) Get(highBandwidth bool) (io.ReadCloser, error) {
 	// use high bandwidth (full size) file download.
-	uri := strings.Replace(f.Link.HREF, "++getfile", "++getfilehb", 1)
+	uri := strings.Replace(f.Link.HREF, "++getfile/", "++getfilelb/", 1)
+	if highBandwidth {
+		uri = strings.Replace(f.Link.HREF, "++getfile/", "++getfilehb/", 1)
+	}
 	resp, err := f.server.secReq(uri, make(url.Values), DefaultTimeout)
 	if err != nil {
 		return nil, err
@@ -116,7 +119,7 @@ func (f *Files) getFiles(cameraNums []int, from, to time.Time, fileTypes, contin
 		// Add the camera, server and file interfaces to every file entry.
 		feed.Entries[i].Camera = f.server.Cameras.ByNum(feed.Entries[i].CameraNum)
 		feed.Entries[i].server = f.server
-		feed.Entries[i].GmtOffset, _ = strconv.Atoi(feed.GmtOffset)
+		feed.Entries[i].GmtOffset = feed.GmtOffset.Duration
 		entries = append(entries, feed.Entries[i])
 	}
 	// ++download automatically paginates. Follow the continuation.

--- a/files_types.go
+++ b/files_types.go
@@ -3,22 +3,25 @@ package securityspy
 import (
 	"encoding/xml"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
-// downloadDateFormat is the format the SecuritySpy ++download method accepts.
-// This matches the ++download inputs AND the folder names files are saved into.
-var downloadDateFormat = "2006-01-02"
+var (
+	// downloadDateFormat is the format the SecuritySpy ++download method accepts.
+	// This matches the ++download inputs AND the folder names files are saved into.
+	// The file1/file2 inputs this gets passed into are actually undocuemnted and were
+	// created specifically for programmtic SDK access (ie. this library).
+	downloadDateFormat = "2006-01-02"
+	// Arbitrary date format used for saved files we hope doesn't change.
+	// This is used in the actual name of files that are saved. No where else.
+	// The GetFile() method uses this to construct arbitrary file download paths.
+	fileDateFormat = "01-02-2006"
 
-// Arbitrary date format used for saved files we hope doesn't change.
-// This is used in the actual name of files that are saved. No where else.
-// The GetFile() method uses this to construct arbitrary file download paths.
-var fileDateFormat = "01-02-2006"
-
-// Errors returned by this file.
-const (
-	ErrorPathExists  = Error("cannot overwrite existing path")
-	ErrorNoExtension = Error("missing file extension")
-	ErrorInvalidName = Error("invalid file name")
+	// Errors returned by this file.
+	ErrorPathExists  = errors.New("cannot overwrite existing path")
+	ErrorNoExtension = errors.New("missing file extension")
+	ErrorInvalidName = errors.New("invalid file name")
 )
 
 // Files powers the Files interface.
@@ -32,7 +35,7 @@ type fileFeed struct {
 	XMLName      xml.Name `xml:"feed"`
 	BSL          string   `xml:"bsl,attr"`     // http://www.bensoftware.com/
 	Title        string   `xml:"title"`        // Downloads
-	GmtOffset    string   `xml:"gmt-offset"`   // -28800
+	GmtOffset    Duration `xml:"gmt-offset"`   // -28800
 	Continuation string   `xml:"continuation"` // 0007E3010C0E1D3A
 	Entries      []*File  `xml:"entry"`        // List of File pointers
 }
@@ -46,9 +49,9 @@ type File struct {
 		Length int64  `xml:"length,attr"` // 358472320, 483306152, 900789978,
 		HREF   string `xml:"href,attr"`   // ++getfile/4/2018-10-17/10-17-2018+M+Gate.m4v
 	} `xml:"link"`
-	Updated   time.Time `xml:"updated"`   // 2019-01-12T08:57:58Z, 201...
-	CameraNum int       `xml:"cameraNum"` // 0, 1, 2, 4, 5, 7, 9, 10, 11, 12, 13
-	GmtOffset int
+	Updated   time.Time     `xml:"updated"`   // 2019-01-12T08:57:58Z, 201...
+	CameraNum int           `xml:"cameraNum"` // 0, 1, 2, 4, 5, 7, 9, 10, 11, 12, 13
+	GmtOffset time.Duration // the rest are copied in per-file from fileFeed.
 	Camera    *Camera
 	server    *Server
 }

--- a/ptz.go
+++ b/ptz.go
@@ -125,8 +125,7 @@ func (z *PTZ) ptzReq(command ptzCommand) error {
 
 // UnmarshalXML method converts ptzCapbilities bitmask into true/false abilities.
 func (z *PTZ) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-	err := d.DecodeElement(&z.rawCaps, &start)
-	if err != nil {
+	if err := d.DecodeElement(&z.rawCaps, &start); err != nil {
 		return errors.Wrap(err, "ptz caps")
 	}
 	z.HasPanTilt = z.rawCaps&ptzPanTilt == ptzPanTilt

--- a/ptz_types.go
+++ b/ptz_types.go
@@ -1,5 +1,12 @@
 package securityspy
 
+import "github.com/pkg/errors"
+
+var (
+	ErrorPTZNotOK = errors.New("PTZ command not OK")
+	ErrorPTZRange = errors.New("PTZ preset out of range 1-8")
+)
+
 // PTZ are what "things" a camera can do.
 type PTZ struct {
 	camera  *Camera

--- a/schedules.go
+++ b/schedules.go
@@ -15,25 +15,8 @@ import (
 
 // SetSchedulePreset invokes a schedule preset. This [may/will] affect all camera arm modes.
 // Find presets you can pass into this method at server.Info.SchedulePresets
-func (s *Server) SetSchedulePreset(schedule SchedulePreset) error {
+func (s *Server) SetSchedulePreset(presetID int) error {
 	params := make(url.Values)
-	params.Set("id", strconv.Itoa(schedule.ID))
+	params.Set("id", strconv.Itoa(presetID))
 	return s.simpleReq("++ssSetPreset", params, -1)
-}
-
-// String provides a description of a Schedule Override.
-func (e ScheduleOverride) String() string {
-	switch e {
-	case ScheduleOverrideNone:
-		return "No Schedule Override"
-	case ScheduleOverrideUnarmedUntilEvent:
-		return "Unarmed Until Next Scheduled Event"
-	case ScheduleOverrideArmedUntilEvent:
-		return "Armed Until Next Scheduled Event"
-	case ScheduleOverrideUnarmedOneHour:
-		return "Unarmed For 1 Hour"
-	case ScheduleOverrideArmedOneHour:
-		return "Armed For 1 Hour"
-	}
-	return "Unknown Schedule Override"
 }

--- a/schedules_types.go
+++ b/schedules_types.go
@@ -1,37 +1,43 @@
 package securityspy
 
+import (
+	"encoding/xml"
+)
+
 // CameraMode is a set of constants to deal with three specific camera modes.
 type CameraMode rune
 
 // Camera modes used by Camera scheduling methods.
 const (
-	CameraModeAll        CameraMode = '*'
+	CameraModeAll        CameraMode = 'X'
 	CameraModeMotion     CameraMode = 'M'
 	CameraModeActions    CameraMode = 'A'
 	CameraModeContinuous CameraMode = 'C'
 )
 
-// CameraMode is a set of constants to deal with three specific camera modes.
-// The String() method returns a description.
-type ScheduleOverride rune
+// scheduleContainer allows unmarshalling of ScheduleOverrides and SchedulePresets into a map.
+type scheduleContainer map[int]string
 
-const (
-	ScheduleOverrideNone ScheduleOverride = iota
-	ScheduleOverrideUnarmedUntilEvent
-	ScheduleOverrideArmedUntilEvent
-	ScheduleOverrideUnarmedOneHour
-	ScheduleOverrideArmedOneHour
-)
-
-// Schedule is for arming and disarming motion, capture, actions, etc.
-// This types holds the schedule's name and its id. Pass this type into
-// Camera schedule methods to set and re-assign schedules on camera parameters.
-type Schedule struct {
-	Name string `xml:"name"` // Unarmed 24/7, Armed 24/7,...
-	ID   int    `xml:"id"`   // 0, 1, 2, 3
-}
-
-type SchedulePreset struct {
-	Name string `xml:"name"` // Unarmed 24/7, Armed 24/7,...
-	ID   int    `xml:"id"`   // 0, 1, 2, 3
+func (m *scheduleContainer) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	for (*m) = make(scheduleContainer); ; {
+		var schedule struct {
+			Name string `xml:"name"`
+			ID   int    `xml:"id"`
+		}
+		token, err := d.Token()
+		if err != nil {
+			return err
+		}
+		switch e := token.(type) {
+		case xml.StartElement:
+			if err = d.DecodeElement(&schedule, &e); err != nil {
+				return err
+			}
+			(*m)[schedule.ID] = schedule.Name
+		case xml.EndElement:
+			if e == start.End() {
+				return nil
+			}
+		}
+	}
 }

--- a/securityspy.go
+++ b/securityspy.go
@@ -26,16 +26,15 @@ func GetServer(user, pass, url string, verifySSL bool) (*Server, error) {
 		authB64 = base64.URLEncoding.EncodeToString([]byte(user + ":" + pass))
 	}
 	server := &Server{
-		systemInfo: new(systemInfo),
+		systemInfo: &systemInfo{Server: &ServerInfo{}},
 		baseURL:    url,
 		authB64:    authB64,
 		username:   user,
 		verifySSL:  verifySSL,
 	}
 	// Assign all the sub-interface structs.
-	server.Info = &server.systemInfo.Server
+	server.Info = server.systemInfo.Server
 	server.Files = &Files{server: server}
-	server.Cameras = &Cameras{server: server}
 	server.Events = &Events{server: server,
 		eventBinds: make(map[EventType][]func(Event)),
 		eventChans: make(map[EventType][]chan Event),
@@ -56,27 +55,34 @@ func GetServer(user, pass, url string, verifySSL bool) (*Server, error) {
 // Refresh gets fresh camera and serverInfo data from SecuritySpy,
 // run this after every action to keep the data pool up to date.
 func (s *Server) Refresh() error {
+	s.Info.Lock()
+	defer s.Info.Unlock()
 	if xmldata, err := s.secReqXML("++systemInfo", nil); err != nil {
 		return err
 	} else if err := xml.Unmarshal(xmldata, s.systemInfo); err != nil {
 		return errors.Wrap(err, "xml.Unmarshal(++systemInfo)")
 	}
 
-	// Add the name to each assigned Camera Schedule.
+	// Point all the unmarshalled data into an exported struct. Better-formatted data.
+	s.Info.Refreshed = time.Now()
+	s.Info.ServerSchedules = s.systemInfo.Schedules
+	s.Info.SchedulePresets = s.systemInfo.SchedulePresets
+	s.Info.ScheduleOverrides = s.systemInfo.ScheduleOverrides
+	s.Cameras = &Cameras{
+		server: s,
+		Count:  len(s.systemInfo.CameraList.Cameras),
+	}
+	// Add the name to each assigned Camera Schedule and Schedule Override.
 	for i, cam := range s.systemInfo.CameraList.Cameras {
-		s.systemInfo.CameraList.Cameras[i].ScheduleIDA.Name = strings.TrimSpace(s.getScheduleName(cam.ScheduleIDA.ID))
-		s.systemInfo.CameraList.Cameras[i].ScheduleIDCC.Name = strings.TrimSpace(s.getScheduleName(cam.ScheduleIDCC.ID))
-		s.systemInfo.CameraList.Cameras[i].ScheduleIDMC.Name = strings.TrimSpace(s.getScheduleName(cam.ScheduleIDMC.ID))
-		s.systemInfo.CameraList.Cameras[i].ScheduleOverrideA.Name = strings.TrimSpace(s.getScheduleName(cam.ScheduleOverrideA.ID))
-		s.systemInfo.CameraList.Cameras[i].ScheduleOverrideCC.Name = strings.TrimSpace(s.getScheduleName(cam.ScheduleOverrideCC.ID))
-		s.systemInfo.CameraList.Cameras[i].ScheduleOverrideMC.Name = strings.TrimSpace(s.getScheduleName(cam.ScheduleOverrideMC.ID))
+		s.systemInfo.CameraList.Cameras[i].ScheduleIDA.Name = s.Info.ServerSchedules[cam.ScheduleIDA.ID]
+		s.systemInfo.CameraList.Cameras[i].ScheduleIDCC.Name = s.Info.ServerSchedules[cam.ScheduleIDCC.ID]
+		s.systemInfo.CameraList.Cameras[i].ScheduleIDMC.Name = s.Info.ServerSchedules[cam.ScheduleIDMC.ID]
+		s.systemInfo.CameraList.Cameras[i].ScheduleOverrideA.Name = s.Info.ScheduleOverrides[cam.ScheduleOverrideA.ID]
+		s.systemInfo.CameraList.Cameras[i].ScheduleOverrideCC.Name = s.Info.ScheduleOverrides[cam.ScheduleOverrideCC.ID]
+		s.systemInfo.CameraList.Cameras[i].ScheduleOverrideMC.Name = s.Info.ScheduleOverrides[cam.ScheduleOverrideMC.ID]
 		s.Cameras.Names = append(s.Cameras.Names, cam.Name)
 		s.Cameras.Numbers = append(s.Cameras.Numbers, cam.Number)
 	}
-	s.systemInfo.Server.SchedulePresets = s.systemInfo.SchedulePresetList.SchedulePresets
-	s.systemInfo.Server.Schedules = s.systemInfo.ScheduleList.Schedules
-	s.systemInfo.Server.Refreshed = time.Now()
-	s.Cameras.Count = len(s.systemInfo.CameraList.Cameras)
 	return nil
 }
 
@@ -88,7 +94,7 @@ func (s *Server) RefreshScripts() error {
 	} else if err := xml.Unmarshal(xmldata, &s.systemInfo.Scripts); err != nil {
 		return errors.Wrap(err, "xml.Unmarshal(++scripts)")
 	}
-	s.systemInfo.Server.ScriptsNames = s.systemInfo.Scripts.Names
+	s.Info.ScriptsNames = s.systemInfo.Scripts.Names
 	return nil
 }
 
@@ -100,7 +106,7 @@ func (s *Server) RefreshSounds() error {
 	} else if err := xml.Unmarshal(xmldata, &s.systemInfo.Sounds); err != nil {
 		return errors.Wrap(err, "xml.Unmarshal(++sounds)")
 	}
-	s.systemInfo.Server.SoundsNames = s.systemInfo.Sounds.Names
+	s.Info.SoundsNames = s.systemInfo.Sounds.Names
 	return nil
 }
 
@@ -125,21 +131,12 @@ func (s *Server) secReq(apiPath string, params url.Values, timeout time.Duration
 		params.Set("format", "xml")
 		req.Header.Add("Accept", "application/xml")
 	}
-	req.URL.RawQuery = encodeRequestParams(params)
+	req.URL.RawQuery = params.Encode()
 	resp, err = a.Do(req)
 	if err != nil {
 		return resp, errors.Wrap(err, "http.Do(req)")
 	}
 	return resp, nil
-}
-
-// encodeRequestParams encodes parameters for securityspy.
-// Some parameters cannot be escaped, namely *'s
-// This function is sorta hacky, but I did ask SecuritySpy support to "support" encoded query parameters.
-// If that support gets added, we can remove this function.
-func encodeRequestParams(params url.Values) string {
-	// Convert stars (asterisks) back to asterisks.
-	return strings.Replace(params.Encode(), "%2A", "*", -1)
 }
 
 // secReqXML returns raw http body, so it can be unmarshaled into an xml struct.
@@ -158,15 +155,6 @@ func (s *Server) secReqXML(apiPath string, params url.Values) (body []byte, err 
 		return body, errors.Wrap(err, "ioutil.ReadAll(resp.Body)")
 	}
 	return body, nil
-}
-
-func (s *Server) getScheduleName(id int) string {
-	for _, schedule := range s.systemInfo.ScheduleList.Schedules {
-		if schedule.ID == id {
-			return schedule.Name
-		}
-	}
-	return "Unknown Schedule"
 }
 
 // simpleReq performes HTTP req, checks for OK at end of output.


### PR DESCRIPTION
- SecuritySpy is now providing a date/time stamp that parses directly into time.Time, so utilize that.
- The seconds from GMT integer has been fixed, so make use of that in event stream messages.
  - All times are now properly localized.
- Schedule Overrides are now provided by ++systemInfo so no longer need to hard code them.
- Don't rely on custom scheduling type and just allow IDs (int) to be used.
- Convert constant errors to top-level variables. They just don't need to be constants.
- Add parameter for high bandwidth vs low bandwidth for file Get method.
- Securityspy now accepts an `X` instead of a `*` for all files, so use that and remove the magic that prevented encoding the *.
- Create custom type for schedules to unmarshal into.
- Make all the schedules more cohesive in the Server struct (all map[int]string now).
