### PR TITLE
Fix SS 5.5 camera Width/Height when video-format is set

### DIFF
--- a/cameras_test.go
+++ b/cameras_test.go
@@ -20,6 +20,38 @@ func TestUnmarshalXMLCameraSchedule(t *testing.T) {
 	asert.Equal(3, s.ID, "the data was not unmarshalled properly")
 }
 
+// SS 5.5 keeps v5 width/height tags but also emits video-format (a v6-era field).
+func TestUnmarshalXMLCameraSS55WithVideoFormat(t *testing.T) {
+	t.Parallel()
+
+	const camXML = `<camera>
+		<number>1</number>
+		<connected>yes</connected>
+		<width>3072</width>
+		<height>1728</height>
+		<mode-c>armed</mode-c>
+		<mode-m>armed</mode-m>
+		<mode-a>armed</mode-a>
+		<hasaudio>yes</hasaudio>
+		<name>Mailbox</name>
+		<devicename>Dahua Technology</devicename>
+		<video-format>H.265</video-format>
+		<audio-format>AAC</audio-format>
+	</camera>`
+
+	var cam securityspy.Camera
+	require.NoError(t, xml.Unmarshal([]byte(camXML), &cam))
+	require.Equal(t, "Mailbox", cam.Name)
+	require.Equal(t, 3072, cam.Width)
+	require.Equal(t, 1728, cam.Height)
+	require.Equal(t, "H.265", cam.VideoFormat)
+	require.Equal(t, "AAC", cam.AudioFormat)
+	require.True(t, cam.ModeM.Val)
+	require.True(t, cam.HasAudio.Val)
+	require.Equal(t, "Dahua Technology", cam.DeviceName)
+	require.Equal(t, "h265", cam.PreferredVCodec())
+}
+
 func TestAll(t *testing.T) {
 	t.Parallel()
 	asert := assert.New(t)

--- a/cameras_types.go
+++ b/cameras_types.go
@@ -344,12 +344,6 @@ func (c *Camera) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 		return fmt.Errorf("decoding camera xml: %w", err)
 	}
 
-	// SS 5.5+ emits video-format / audio-format on the v5 schema; do not treat
-	// those alone as v6 (that left Width/Height at 0 from empty video-width tags).
-	isV6 := raw.WidthV6 != 0 || raw.HeightV6 != 0 || raw.CapturePathV6 != "" ||
-		raw.DeviceNameV6 != "" || raw.ModeCV6.Txt != "" || raw.HasAudioV6.Txt != "" ||
-		raw.PTZV6 != nil || raw.StoragePathSet()
-
 	c.Number = raw.Number
 	c.Connected = raw.Connected
 	c.Name = raw.Name
@@ -365,7 +359,7 @@ func (c *Camera) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	c.Overlay = raw.Overlay
 	c.OverlayText = firstNonEmpty(raw.OverlayTextV6, raw.OverlayText)
 
-	if isV6 {
+	if raw.isV6() {
 		c.Width = raw.WidthV6
 		c.Height = raw.HeightV6
 		c.ModeC = raw.ModeCV6
@@ -446,6 +440,7 @@ func (c *Camera) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	if c.Width == 0 {
 		c.Width = firstNonZero(raw.WidthV5, raw.WidthV6)
 	}
+
 	if c.Height == 0 {
 		c.Height = firstNonZero(raw.HeightV5, raw.HeightV6)
 	}
@@ -484,8 +479,14 @@ func (c *Camera) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	return nil
 }
 
-func (x *cameraXML) StoragePathSet() bool {
-	return x.CapturePathV6 != ""
+// isV6 reports whether this camera element used SecuritySpy 6+ tags
+// (video-width/height, storage-path, device-name, cc-mode, has-audio, ptz-features).
+// Shared fields like video-format also appear on SS 5.5's v5 schema, so they
+// must not be used as the sole signal.
+func (x *cameraXML) isV6() bool {
+	return x.WidthV6 != 0 || x.HeightV6 != 0 || x.CapturePathV6 != "" ||
+		x.DeviceNameV6 != "" || x.ModeCV6.Txt != "" || x.HasAudioV6.Txt != "" ||
+		x.PTZV6 != nil
 }
 
 func firstNonEmpty(values ...string) string {

--- a/cameras_types.go
+++ b/cameras_types.go
@@ -337,7 +337,7 @@ type cameraXML struct {
 
 // UnmarshalXML decodes v5 or v6 ++systemInfo camera elements into Camera.
 //
-//nolint:cyclop,funlen // dual schema mapping
+//nolint:funlen // dual schema mapping
 func (c *Camera) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	var raw cameraXML
 	if err := d.DecodeElement(&raw, &start); err != nil {

--- a/cameras_types.go
+++ b/cameras_types.go
@@ -344,9 +344,11 @@ func (c *Camera) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 		return fmt.Errorf("decoding camera xml: %w", err)
 	}
 
+	// SS 5.5+ emits video-format / audio-format on the v5 schema; do not treat
+	// those alone as v6 (that left Width/Height at 0 from empty video-width tags).
 	isV6 := raw.WidthV6 != 0 || raw.HeightV6 != 0 || raw.CapturePathV6 != "" ||
 		raw.DeviceNameV6 != "" || raw.ModeCV6.Txt != "" || raw.HasAudioV6.Txt != "" ||
-		raw.PTZV6 != nil || raw.VideoFormat != "" || raw.StoragePathSet()
+		raw.PTZV6 != nil || raw.StoragePathSet()
 
 	c.Number = raw.Number
 	c.Connected = raw.Connected
@@ -440,6 +442,14 @@ func (c *Camera) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 		c.TLrecordAudio = raw.TLrecordAudio
 	}
 
+	// Prefer the other schema's dimensions when the chosen branch left them unset.
+	if c.Width == 0 {
+		c.Width = firstNonZero(raw.WidthV5, raw.WidthV6)
+	}
+	if c.Height == 0 {
+		c.Height = firstNonZero(raw.HeightV5, raw.HeightV6)
+	}
+
 	c.NetworkAudio = c.AudioNetwork
 	c.ActionSoundCam = raw.ActionSoundCam
 	c.ActionSoundMac = raw.ActionSoundMac
@@ -486,4 +496,14 @@ func firstNonEmpty(values ...string) string {
 	}
 
 	return ""
+}
+
+func firstNonZero(values ...int) int {
+	for _, v := range values {
+		if v != 0 {
+			return v
+		}
+	}
+
+	return 0
 }


### PR DESCRIPTION
## Summary
- Stop treating `video-format` alone as a v6 camera schema signal (SS 5.5 keeps width/height v5 tags but also emits video-format).
- Fall back to the other schema's dimensions when the chosen branch leaves Width/Height unset.
- Add a regression test for an SS 5.5-style camera with video-format + v5 geometry tags.

Without this, clients that scale clips from camera height (e.g. Motifini half/quarter) request no size and get oversized native streams that hit size limits almost immediately.

## Test plan
- [x] `go test ./...`
- [x] Live SS 5.5.11 Refresh: Mailbox parses as 3072x1728 (was 0x0)
- [x] Live half-scale Mailbox clip returns ~1532x862 instead of a sub-second full-res file
